### PR TITLE
Add an option to force pre-O apps to use full screen aspect ratio

### DIFF
--- a/core/res/res/values/toxyc_config.xml
+++ b/core/res/res/values/toxyc_config.xml
@@ -70,4 +70,8 @@
     <!-- Whether navigation bar can be disabled (for devices with hardware keys) -->
     <bool name="config_canDisableNavigationBar">false</bool>
 
+    <!-- Full screen aspect ratio -->
+    <bool name="config_haveHigherAspectRatioScreen">false</bool>
+    <item name="config_screenAspectRatio" format="float" type="dimen">2.1</item>
+
 </resources>

--- a/core/res/res/values/toxyc_symbols.xml
+++ b/core/res/res/values/toxyc_symbols.xml
@@ -83,4 +83,8 @@
   <!-- Whether navigation bar can be disabled (for devices with hardware keys) -->
   <java-symbol type="bool" name="config_canDisableNavigationBar" />
 
+  <!-- Full screen aspect ratio -->
+  <java-symbol type="bool" name="config_haveHigherAspectRatioScreen" />
+  <java-symbol type="dimen" name="config_screenAspectRatio" />
+
 </resources>

--- a/services/core/java/com/android/server/am/ActivityRecord.java
+++ b/services/core/java/com/android/server/am/ActivityRecord.java
@@ -131,6 +131,7 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.res.CompatibilityInfo;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.GraphicBuffer;
 import android.graphics.Rect;
@@ -347,6 +348,10 @@ final class ActivityRecord extends ConfigurationContainer implements AppWindowCo
 
     private boolean mShowWhenLocked;
     private boolean mTurnScreenOn;
+
+    // Full screen aspect ratio
+    private final float mFullScreenAspectRatio = Resources.getSystem().getFloat(
+                    com.android.internal.R.dimen.config_screenAspectRatio);
 
     /**
      * Temp configs used in {@link #ensureActivityConfigurationLocked(int, boolean)}
@@ -2284,7 +2289,9 @@ final class ActivityRecord extends ConfigurationContainer implements AppWindowCo
     // TODO(b/36505427): Consider moving this method and similar ones to ConfigurationContainer.
     private void computeBounds(Rect outBounds) {
         outBounds.setEmpty();
-        final float maxAspectRatio = info.maxAspectRatio;
+        final boolean higherAspectRatio = Resources.getSystem().getBoolean(
+                com.android.internal.R.bool.config_haveHigherAspectRatioScreen);
+        final float maxAspectRatio = higherAspectRatio ? mFullScreenAspectRatio : info.maxAspectRatio;
         final ActivityStack stack = getStack();
         if (task == null || stack == null || !task.mFullscreen || maxAspectRatio == 0
                 || isInVrUiMode(getConfiguration())) {


### PR DESCRIPTION
Add an option to force pre-O apps to use full screen aspect ratio

When an app target pre-O releases, the default max aspect ratio
is 1.86:1 which leads to ugly black areas on devices that have
screens with higher aspect ratio (for example Galaxy S8/S9).

This change adds an option to allow users to change default
aspect ratio for pre-O apps to 2.1 which would fit recent devices.

@wight554
Simplify the code, we don't need the Settings for that, just bool
